### PR TITLE
アイテムの比較にequalsを使用する

### DIFF
--- a/src/lazyperson0710/ItemUseCancel/event/PlayerItemEvent.php
+++ b/src/lazyperson0710/ItemUseCancel/event/PlayerItemEvent.php
@@ -50,7 +50,7 @@ class PlayerItemEvent implements Listener {
             VanillaItems::ENCHANTED_GOLDEN_APPLE(),
         ];
         foreach ($items as $item) {
-            if ($item->equals($inHand)) {
+            if ($item->equals($inHand, false, false)) {
                 $player->sendTip("ロビーでは金リンゴの使用は許可されていません");
                 $event->cancel();
                 break;

--- a/src/lazyperson0710/ItemUseCancel/event/PlayerItemEvent.php
+++ b/src/lazyperson0710/ItemUseCancel/event/PlayerItemEvent.php
@@ -5,6 +5,7 @@ namespace lazyperson0710\ItemUseCancel\event;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerItemUseEvent;
+use pocketmine\item\Item;
 use pocketmine\item\Potion;
 use pocketmine\item\SplashPotion;
 use pocketmine\item\VanillaItems;
@@ -43,13 +44,17 @@ class PlayerItemEvent implements Listener {
             $player->sendTip("ロビーではスプラッシュポーションの使用は許可されていません");
             $event->cancel();
         }
+        /** @var Item[] $items */
         $items = [
-            VanillaItems::GOLDEN_APPLE()->getVanillaName(),
-            VanillaItems::ENCHANTED_GOLDEN_APPLE()->getVanillaName(),
+            VanillaItems::GOLDEN_APPLE(),
+            VanillaItems::ENCHANTED_GOLDEN_APPLE(),
         ];
-        if (in_array($inHand->getVanillaName(), $items)) {
-            $player->sendTip("ロビーでは金リンゴの使用は許可されていません");
-            $event->cancel();
+        foreach ($items as $item) {
+            if ($item->equals($inHand)) {
+                $player->sendTip("ロビーでは金リンゴの使用は許可されていません");
+                $event->cancel();
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
PMでは同じ名前を持つアイテムを登録することができるみたいなので、文字列で比較するより、信頼性が高い(はず)
そもそも `GoldenAppleEnchanted` は `GoldenApple` を継承しているので、実用上は `instanceof GoldenApple` でも良いかも...(その場合、元のコードとは違ってエンチャント金リンゴ以外の、金リンゴを継承するアイテムも対象になる)