### PR TITLE
不要な条件分岐を削除

### DIFF
--- a/src/lazyperson0710/ItemUseCancel/event/PlayerItemEvent.php
+++ b/src/lazyperson0710/ItemUseCancel/event/PlayerItemEvent.php
@@ -17,7 +17,6 @@ class PlayerItemEvent implements Listener {
      * @priority LOW
      */
     public function onItemUse(PlayerItemUseEvent $event): void {
-        if ($event->isCancelled()) return;
         $this->onItemEvents($event);
     }
 
@@ -27,7 +26,6 @@ class PlayerItemEvent implements Listener {
      * @priority LOW
      */
     public function onItemInteract(PlayerInteractEvent $event): void {
-        if ($event->isCancelled()) return;
         $this->onItemEvents($event);
     }
 


### PR DESCRIPTION
`@handleCancelled` が指定されていない場合は、キャンセルされたイベントがハンドルされないので多分不要
https://github.com/pmmp/PocketMine-MP/blob/d77a95e4aff2c94312ce1dd3d8c4cfd2c7cdecc4/src/event/Listener.php#L46